### PR TITLE
feat: 파일/폴더 삭제 기능 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { ZipHandler } from './utils/zipHandler';
+import { ZipHandler, type ZipNode } from './utils/zipHandler';
 import { renderFileTree, highlightTreeNode } from './ui/treeView';
 import { Editor } from './ui/editor';
 import { saveAs } from 'file-saver';
@@ -19,25 +19,136 @@ const downloadBtn = document.getElementById('btn-download') as HTMLButtonElement
 
 let currentFileName = '';
 
+const criticalFiles = [
+    '[Content_Types].xml',
+    'document.xml',
+    'workbook.xml',
+    'presentation.xml',
+    'content.xml',
+    'styles.xml',
+    'settings.xml',
+    'app.xml',
+    'core.xml'
+];
+
 // File Handling
 async function handleFile(file: File) {
     try {
         await zipHandler.loadAsync(file);
-        const tree = zipHandler.getFileTree();
-
         currentFileName = file.name;
         fileNameDisplay.textContent = `(${file.name})`;
         downloadBtn.disabled = false;
 
-        renderFileTree(sidebarTree, tree, (node) => {
-            editor.loadFile(node);
-        });
-
+        refreshFileTree();
         editor.reset();
         dropZone.classList.add('hidden');
     } catch (error) {
         console.error(error);
         alert('Failed to load file');
+    }
+}
+
+function refreshFileTree() {
+    // Save currently open folders
+    const openFolders = new Set<string>();
+    sidebarTree.querySelectorAll('.tree-children.open').forEach(ul => {
+        const li = ul.parentElement;
+        if (li) {
+            const content = li.querySelector('.tree-content');
+            if (content) {
+                const path = content.getAttribute('data-path');
+                if (path) openFolders.add(path);
+            }
+        }
+    });
+
+    const tree = zipHandler.getFileTree();
+    renderFileTree(
+        sidebarTree,
+        tree,
+        async (node) => {
+            await editor.loadFile(node);
+        },
+        (node) => {
+            handleDelete(node);
+        }
+    );
+
+    // Restore open folders
+    openFolders.forEach(path => {
+        const safePath = path.replace(/"/g, '\\"');
+        const content = sidebarTree.querySelector(`.tree-content[data-path="${safePath}"]`);
+        if (content) {
+            const li = content.parentElement;
+            if (li) {
+                const childrenContainer = li.querySelector('.tree-children');
+                const toggle = content.querySelector('.tree-toggle') as HTMLElement;
+                const icon = content.querySelector('.tree-icon') as HTMLElement;
+
+                if (childrenContainer) {
+                    childrenContainer.classList.add('open');
+                    if (toggle) toggle.style.transform = 'rotate(90deg)';
+                    if (icon) icon.textContent = '📂';
+                }
+            }
+        }
+    });
+}
+
+function handleDelete(node: ZipNode) {
+    const itemType = node.isDir ? '폴더' : '파일';
+    let message = `"${node.name}" ${itemType}을(를) 삭제하시겠습니까?`;
+
+    // Add file count for folders
+    if (node.isDir) {
+        const fileCount = zipHandler.countFilesInFolder(node.path);
+        message = `"${node.name}" 폴더를 삭제하시겠습니까?\n(${fileCount}개 파일 포함)`;
+    }
+
+    // Check if it's a critical file
+    const isCritical = criticalFiles.some(critical =>
+        node.path.endsWith(critical) || node.name === critical
+    );
+
+    if (isCritical) {
+        message += '\n\n⚠️ 경고: 이 파일은 문서의 핵심 파일입니다.\n삭제하면 문서가 손상될 수 있습니다.';
+    }
+
+    if (confirm(message)) {
+        // Find and animate the tree node before deletion
+        const safePath = node.path.replace(/"/g, '\\"');
+        const treeContent = sidebarTree.querySelector(`.tree-content[data-path="${safePath}"]`);
+
+        if (treeContent) {
+            const treeNode = treeContent.parentElement; // li element
+            treeContent.classList.add('deleting');
+
+            // If it's a folder with children, animate children too
+            if (treeNode) {
+                const childrenContainer = treeNode.querySelector('.tree-children');
+                if (childrenContainer) {
+                    childrenContainer.classList.add('deleting');
+                }
+            }
+        }
+
+        // Wait for animation to complete, then delete
+        setTimeout(() => {
+            if (node.isDir) {
+                zipHandler.deleteFolder(node.path);
+            } else {
+                zipHandler.deleteFile(node.path);
+            }
+
+            // Check if currently open file is deleted
+            const currentPath = editor.getCurrentFilePath();
+            if (currentPath && (currentPath === node.path || currentPath.startsWith(node.path + '/'))) {
+                editor.reset();
+            }
+
+            // Refresh tree
+            refreshFileTree();
+        }, 300); // Match CSS transition duration
     }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -166,6 +166,22 @@ main {
     border: 1px solid var(--accent-color);
 }
 
+.tree-content.deleting {
+    opacity: 0;
+    transform: translateX(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.tree-node.deleting > .tree-content {
+    opacity: 0;
+    transform: translateX(-10px);
+}
+
+.tree-children.deleting {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
 .tree-icon {
     margin-right: 6px;
     width: 16px;

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -451,4 +451,8 @@ export class Editor {
         this.emptyState.classList.remove('hidden');
         this.editorContainer.classList.add('hidden');
     }
+
+    getCurrentFilePath(): string | null {
+        return this.currentNode ? this.currentNode.path : null;
+    }
 }

--- a/src/utils/zipHandler.ts
+++ b/src/utils/zipHandler.ts
@@ -82,4 +82,38 @@ export class ZipHandler {
     async generateZip(type: 'blob' = 'blob'): Promise<Blob> {
         return await this.zip.generateAsync({ type });
     }
+
+    deleteFile(path: string): void {
+        this.zip.remove(path);
+    }
+
+    deleteFolder(path: string): void {
+        // Remove folder and all its contents
+        const normalizedPath = path.endsWith('/') ? path : path + '/';
+
+        // Collect all files to delete
+        const filesToDelete: string[] = [];
+        this.zip.forEach((relativePath) => {
+            if (relativePath.startsWith(normalizedPath) || relativePath === path) {
+                filesToDelete.push(relativePath);
+            }
+        });
+
+        // Delete all collected files
+        filesToDelete.forEach(file => this.zip.remove(file));
+    }
+
+    countFilesInFolder(path: string): number {
+        const normalizedPath = path.endsWith('/') ? path : path + '/';
+        let count = 0;
+
+        this.zip.forEach((relativePath, zipEntry) => {
+            // Only count files (not directories) within this folder
+            if (relativePath.startsWith(normalizedPath) && !zipEntry.dir) {
+                count++;
+            }
+        });
+
+        return count;
+    }
 }


### PR DESCRIPTION
- 파일 트리의 각 항목에 마우스 오버 시 휴지통 아이콘 표시
- 폴더 삭제 시 포함된 파일 개수 표시 (예: 15개 파일 포함)
- 핵심 파일(document.xml, workbook.xml 등) 삭제 시 경고 메시지 표시
- 삭제 시 부드러운 페이드아웃 애니메이션 추가
- 트리에서 삭제된 파일/폴더는 다운로드 시 ZIP에서 제외됨
- 삭제 후 열려있던 폴더 상태 유지