### PR TITLE
feat: Diff 모드 구현 및 클래스 상속 구조 리팩토링

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,40 @@ Chrome Extension으로도 사용할 수 있습니다.
 - 💡 Relationship Tooltip (rId 마우스 오버 시 타겟 파일 표시)
 - 🎨 다크 모드 UI
 - 💾 실시간 저장 및 다운로드
+- 🔄 Diff 모드 (두 파일 비교)
+- 🗑️ 파일/폴더 삭제 기능
+
+## 🏗️ 아키텍처
+
+### 클래스 계층 구조
+
+**Mode 계층:**
+```
+BaseMode (공통 트리 관리 및 애니메이션)
+  ├─ Mode (단일 파일 모드)
+  └─ DiffMode (비교 모드)
+```
+
+**Editor 계층:**
+```
+BaseEditor (공통 관계 처리 및 XML 포매팅)
+  ├─ Editor (단일 편집기)
+  └─ DiffEditor (비교 편집기)
+```
+
+**UI 컴포넌트:**
+- `TreeView`: isDiffMode 플래그로 단일/비교 모드 지원
+- `ZipHandler`: JSZip 래퍼, 파일 CRUD 작업
+
+### 주요 디렉터리
+```
+src/
+  modes/        # 애플리케이션 모드 (Single/Diff)
+  ui/           # UI 컴포넌트 (Editor, TreeView)
+  utils/        # 유틸리티 (ZipHandler, DiffUtils, DomUtils)
+  types/        # TypeScript 타입 정의
+  const/        # 상수 정의
+```
 
 ## 📄 지원 파일 형식
 

--- a/index.html
+++ b/index.html
@@ -15,12 +15,29 @@
       <div class="logo">
         <span class="icon">📄</span>
         <h1>OOXML/ODF Viewer</h1>
+
+        <!-- Single Mode File Name -->
         <span id="file-name"></span>
+
+        <!-- Diff Mode File Names (Initially Hidden) -->
+        <div id="diff-file-names" class="hidden">
+          <span id="left-file-name" class="diff-file-label"></span>
+          <span class="diff-separator">⟷</span>
+          <span id="right-file-name" class="diff-file-label"></span>
+        </div>
       </div>
       <div class="actions">
+        <!-- Single Mode Download (Initially Visible) -->
         <button id="btn-download" disabled>Download</button>
-        <label for="file-upload" class="btn-primary">Open File</label>
-        <input type="file" id="file-upload" accept=".docx,.xlsx,.pptx,.odt,.ods,.odp,.show" hidden />
+
+        <!-- Diff Mode Downloads (Initially Hidden) -->
+        <div id="diff-download-btns" class="hidden">
+          <button id="btn-download-left" disabled>Download Left</button>
+          <button id="btn-download-right" disabled>Download Right</button>
+        </div>
+
+        <label for="file-upload" class="btn-primary">Open File(s)</label>
+        <input type="file" id="file-upload" accept=".docx,.xlsx,.pptx,.odt,.ods,.odp,.show" multiple hidden />
       </div>
     </header>
     <main>
@@ -30,6 +47,7 @@
       </div>
       <div id="resizer"></div>
       <div id="editor-area">
+        <!-- Single Mode Editor -->
         <div id="editor-container" class="hidden">
           <div class="editor-toolbar">
             <span id="current-path"></span>
@@ -37,6 +55,20 @@
           </div>
           <div id="editor-content"></div>
         </div>
+
+        <!-- Diff Mode Editor (Initially Hidden) -->
+        <div id="diff-editor-container" class="hidden">
+          <div class="diff-editor-toolbar">
+            <span id="diff-current-path"></span>
+          </div>
+          <div class="diff-editor-controls">
+            <button id="btn-save-left" disabled>Save</button>
+            <button id="btn-save-right" disabled>Save</button>
+          </div>
+          <div id="diff-editor-content"></div>
+        </div>
+
+        <!-- Empty State -->
         <div id="empty-state">
           <p>Select a file to view or edit</p>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@codemirror/commands": "^6.10.0",
         "@codemirror/lang-xml": "^6.1.0",
         "@codemirror/language": "^6.11.3",
+        "@codemirror/merge": "^6.11.2",
         "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.5.2",
         "@codemirror/theme-one-dark": "^6.1.3",
@@ -314,6 +315,19 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.11.2.tgz",
+      "integrity": "sha512-NO5EJd2rLRbwVWLgMdhIntDIhfDtMOKYEZgqV5WnkNUS2oXOCVWLPjG/kgl/Jth2fGiOuG947bteqxP9nBXmMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
       }
     },
     "node_modules/@codemirror/search": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@codemirror/commands": "^6.10.0",
     "@codemirror/lang-xml": "^6.1.0",
     "@codemirror/language": "^6.11.3",
+    "@codemirror/merge": "^6.11.2",
     "@codemirror/search": "^6.5.11",
     "@codemirror/state": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.3",

--- a/src/const/constants.ts
+++ b/src/const/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Critical files that should show warning when deleting
+ */
+export const CRITICAL_FILES = [
+    '[Content_Types].xml',
+    'document.xml',
+    'workbook.xml',
+    'presentation.xml',
+    'content.xml',
+    'styles.xml',
+    'settings.xml',
+    'app.xml',
+    'core.xml'
+] as const;
+
+/**
+ * Desktop minimum width threshold
+ */
+export const DESKTOP_MIN_WIDTH = 768;
+
+/**
+ * Sidebar width constraints
+ */
+export const SIDEBAR_WIDTH = {
+    MIN: 150,
+    MAX: 600
+} as const;
+
+/**
+ * Animation duration for deletion
+ */
+export const DELETE_ANIMATION_DURATION = 300; // ms
+
+/**
+ * File extensions
+ */
+export const FILE_EXTENSIONS = {
+    XML: ['.xml', '.rels'],
+    IMAGE: ['.png', '.jpg', '.jpeg', '.gif']
+} as const;

--- a/src/lib/codemirror.ts
+++ b/src/lib/codemirror.ts
@@ -1,0 +1,201 @@
+import { EditorView, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, highlightActiveLine, keymap } from "@codemirror/view"
+import { EditorState } from "@codemirror/state"
+import { foldGutter, indentOnInput, syntaxHighlighting, bracketMatching, foldKeymap, defaultHighlightStyle, HighlightStyle } from "@codemirror/language"
+import { history, defaultKeymap, historyKeymap } from "@codemirror/commands"
+import { searchKeymap, search } from "@codemirror/search"
+import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete"
+import { lintKeymap } from "@codemirror/lint"
+import { xml } from "@codemirror/lang-xml"
+import { tags as t } from "@lezer/highlight"
+
+/**
+ * Dark theme for CodeMirror
+ */
+export const editorTheme = EditorView.theme({
+    "&": {
+        color: "#e0e0e0",
+        backgroundColor: "#1e1e1e",
+        height: "100%",
+        fontSize: "14px",
+        fontFamily: "'Menlo', 'Consolas', 'Monaco', 'Liberation Mono', 'Lucida Console', monospace"
+    },
+    ".cm-foldPlaceholder": {
+        backgroundColor: "transparent",
+        border: "none",
+        color: "#e0e0e0"
+    },
+    ".cm-content": {
+        caretColor: "#aeafad"
+    },
+    "&.cm-focused .cm-cursor": {
+        borderLeftColor: "#aeafad"
+    },
+    "&.cm-focused .cm-selectionBackground, ::selection": {
+        backgroundColor: "#3E4451"
+    },
+    ".cm-gutters": {
+        backgroundColor: "#1e1e1e",
+        color: "#5c6370",
+        border: "none"
+    },
+    // Search Panel Styles
+    ".cm-search": {
+        backgroundColor: "#2c313a",
+        color: "#ffffff",
+        border: "1px solid #4b5563",
+        borderRadius: "6px",
+        padding: "6px 12px",
+        fontWeight: "bold",
+        fontSize: "15px",
+        display: "flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+        gap: "8px",
+        maxWidth: "100%"
+    },
+    ".cm-search input:not([type='checkbox'])": {
+        backgroundColor: "#1f2937",
+        color: "#e0e0e0",
+        border: "1px solid #4b5563",
+        borderRadius: "4px",
+        padding: "6px 10px",
+        fontSize: "15px",
+        minWidth: "200px"
+    },
+    ".cm-search button": {
+        color: "#e0e0e0",
+        cursor: "pointer",
+        fontWeight: "bold",
+        padding: "4px 8px",
+        fontSize: "13px",
+        backgroundColor: "#374151",
+        border: "1px solid #4b5563",
+        borderRadius: "4px",
+        textTransform: "capitalize"
+    },
+    ".cm-search button:hover": {
+        backgroundColor: "#4b5563"
+    },
+    ".cm-search label": {
+        color: "#e0e0e0",
+        fontWeight: "bold",
+        fontSize: "13px",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "4px",
+        whiteSpace: "nowrap",
+        cursor: "pointer"
+    },
+    ".cm-search input[type='checkbox']": {
+        margin: "0",
+        cursor: "pointer"
+    },
+    // Tooltip Styles
+    ".cm-tooltip": {
+        backgroundColor: "#2c313a",
+        color: "#e0e0e0",
+        border: "1px solid #4b5563",
+        borderRadius: "4px",
+        padding: "4px 8px",
+        fontSize: "12px",
+        zIndex: "100"
+    }
+}, { dark: true });
+
+/**
+ * Syntax highlighting style for XML
+ */
+export const xmlHighlightStyle = HighlightStyle.define([
+    { tag: t.angleBracket, color: "#e02275" },
+    { tag: t.tagName, color: "#e06275" },
+    { tag: t.attributeName, color: "#98c379" },
+    { tag: t.attributeValue, color: "#e5c07b" },
+    { tag: t.string, color: "#e5c07b" },
+    { tag: t.comment, color: "#5c6370", fontStyle: "italic" },
+    { tag: t.content, color: "#abb2bf" }
+]);
+
+/**
+ * Custom fold gutter marker
+ */
+export function createFoldMarker(open: boolean): HTMLElement {
+    const span = document.createElement("span");
+    span.style.cursor = "pointer";
+    span.style.display = "flex";
+    span.style.alignItems = "center";
+    span.style.justifyContent = "center";
+    span.style.width = "16px";
+    span.style.height = "100%";
+
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "17");
+    svg.setAttribute("height", "17");
+    svg.setAttribute("viewBox", "0 0 20 20");
+    svg.setAttribute("fill", "#9ca3af");
+
+    if (open) {
+        // Down Arrow
+        svg.innerHTML = '<path d="M7 10l5 5 5-5z" />';
+    } else {
+        // Right Arrow
+        svg.innerHTML = '<path d="M10 17l5-5-5-5z" />';
+    }
+
+    span.appendChild(svg);
+    return span;
+}
+
+/**
+ * Get common editor extensions
+ */
+export function getCommonExtensions(options?: { excludeSearch?: boolean }) {
+    const extensions = [
+        lineNumbers(),
+        highlightActiveLineGutter(),
+        highlightSpecialChars(),
+        history(),
+        foldGutter({
+            markerDOM: createFoldMarker
+        }),
+        drawSelection(),
+        dropCursor(),
+        EditorState.allowMultipleSelections.of(true),
+        indentOnInput(),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        bracketMatching(),
+        closeBrackets(),
+        autocompletion(),
+        highlightActiveLine(),
+        xml(),
+        editorTheme,
+        syntaxHighlighting(xmlHighlightStyle)
+    ];
+
+    if (!options?.excludeSearch) {
+        extensions.push(
+            search({ top: true }),
+            keymap.of([
+                ...closeBracketsKeymap,
+                ...defaultKeymap,
+                ...searchKeymap,
+                ...historyKeymap,
+                ...foldKeymap,
+                ...completionKeymap,
+                ...lintKeymap
+            ])
+        );
+    } else {
+        extensions.push(
+            keymap.of([
+                ...closeBracketsKeymap,
+                ...defaultKeymap,
+                ...historyKeymap,
+                ...foldKeymap,
+                ...completionKeymap,
+                ...lintKeymap
+            ])
+        );
+    }
+
+    return extensions;
+}

--- a/src/modes/baseMode.ts
+++ b/src/modes/baseMode.ts
@@ -1,0 +1,115 @@
+import { TreeView } from '../ui/treeView';
+import { DELETE_ANIMATION_DURATION, CRITICAL_FILES } from '../const/constants';
+
+/**
+ * Base class for application modes (Single and Diff)
+ * Provides common functionality for tree management and animations
+ */
+export abstract class BaseMode {
+    protected sidebarTree: HTMLElement;
+    protected treeView: TreeView;
+
+    constructor(isDiffMode: boolean = false) {
+        this.sidebarTree = document.getElementById('file-tree')!;
+        this.treeView = new TreeView(this.sidebarTree, isDiffMode);
+    }
+
+    /**
+     * Clear sidebar tree content
+     */
+    protected clearSidebarTree(): void {
+        this.sidebarTree.innerHTML = '';
+    }
+
+    /**
+     * Add critical file warning to message if node is critical
+     */
+    protected addCriticalFileWarning(message: string, path: string, name: string): string {
+        const isCritical = CRITICAL_FILES.some(critical =>
+            path.endsWith(critical) || name === critical
+        );
+
+        if (isCritical) {
+            return message + '\n\n⚠️ 경고: 이 파일은 문서의 핵심 파일입니다.\n삭제하면 문서가 손상될 수 있습니다.';
+        }
+
+        return message;
+    }
+
+    /**
+     * Save currently open folders
+     */
+    protected saveOpenFolders(): Set<string> {
+        const openFolders = new Set<string>();
+        this.sidebarTree.querySelectorAll('.tree-children.open').forEach(ul => {
+            const li = ul.parentElement;
+            if (li) {
+                const content = li.querySelector('.tree-content');
+                if (content) {
+                    const path = content.getAttribute('data-path');
+                    if (path) openFolders.add(path);
+                }
+            }
+        });
+        return openFolders;
+    }
+
+    /**
+     * Restore open folders
+     */
+    protected restoreOpenFolders(openFolders: Set<string>): void {
+        openFolders.forEach(path => {
+            const safePath = path.replace(/"/g, '\\"');
+            const content = this.sidebarTree.querySelector(`.tree-content[data-path="${safePath}"]`);
+            if (content) {
+                const li = content.parentElement;
+                if (li) {
+                    const childrenContainer = li.querySelector('.tree-children');
+                    const toggle = content.querySelector('.tree-toggle') as HTMLElement;
+                    const icon = content.querySelector('.tree-icon') as HTMLElement;
+
+                    if (childrenContainer) {
+                        childrenContainer.classList.add('open');
+                        if (toggle) toggle.style.transform = 'rotate(90deg)';
+                        if (icon) icon.textContent = '📂';
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Animate node deletion
+     */
+    protected animateNodeDeletion(path: string): void {
+        const safePath = path.replace(/"/g, '\\"');
+        const treeContent = this.sidebarTree.querySelector(`.tree-content[data-path="${safePath}"]`);
+
+        if (treeContent) {
+            const treeNode = treeContent.parentElement; // li element
+            treeContent.classList.add('deleting');
+
+            // If it's a folder with children, animate children too
+            if (treeNode) {
+                const childrenContainer = treeNode.querySelector('.tree-children');
+                if (childrenContainer) {
+                    childrenContainer.classList.add('deleting');
+                }
+            }
+        }
+    }
+
+    /**
+     * Wait for animation to complete
+     */
+    protected waitForAnimation(): Promise<void> {
+        return new Promise(resolve => {
+            setTimeout(resolve, DELETE_ANIMATION_DURATION);
+        });
+    }
+
+    /**
+     * Abstract methods to be implemented by subclasses
+     */
+    abstract cleanup(): void;
+}

--- a/src/modes/diffMode.ts
+++ b/src/modes/diffMode.ts
@@ -1,0 +1,173 @@
+import { ZipHandler } from '../utils/zipHandler';
+import { mergeFileTrees, computeDiffStatuses } from '../utils/diffUtils';
+import { BaseMode } from './baseMode';
+import { DiffEditor } from '../ui/diffEditor';
+import { saveAs } from 'file-saver';
+import type { MergedZipNode } from '../types/diff';
+
+export class DiffMode extends BaseMode {
+    private leftZipHandler: ZipHandler;
+    private rightZipHandler: ZipHandler;
+    private diffEditor: DiffEditor;
+    private leftFileName: string = '';
+    private rightFileName: string = '';
+
+    private leftFileNameDisplay: HTMLElement;
+    private rightFileNameDisplay: HTMLElement;
+    private downloadLeftBtn: HTMLButtonElement;
+    private downloadRightBtn: HTMLButtonElement;
+
+    constructor() {
+        super(true); // Diff mode
+
+        this.leftZipHandler = new ZipHandler();
+        this.rightZipHandler = new ZipHandler();
+        this.leftFileNameDisplay = document.getElementById('left-file-name')!;
+        this.rightFileNameDisplay = document.getElementById('right-file-name')!;
+        this.downloadLeftBtn = document.getElementById('btn-download-left') as HTMLButtonElement;
+        this.downloadRightBtn = document.getElementById('btn-download-right') as HTMLButtonElement;
+
+        this.diffEditor = new DiffEditor(this.leftZipHandler, this.rightZipHandler, (path) => {
+            this.treeView.highlightTreeNode(path);
+        });
+
+        this.downloadLeftBtn.addEventListener('click', () => this.downloadLeftFile());
+        this.downloadRightBtn.addEventListener('click', () => this.downloadRightFile());
+    }
+
+    async initialize(leftFile: File, rightFile: File) {
+        try {
+            await this.leftZipHandler.loadAsync(leftFile);
+            await this.rightZipHandler.loadAsync(rightFile);
+
+            this.leftFileName = leftFile.name;
+            this.rightFileName = rightFile.name;
+
+            this.leftFileNameDisplay.textContent = leftFile.name;
+            this.rightFileNameDisplay.textContent = rightFile.name;
+
+            this.downloadLeftBtn.disabled = false;
+            this.downloadRightBtn.disabled = false;
+
+            await this.refreshDiffTree();
+            this.diffEditor.reset();
+        } catch (error) {
+            console.error(error);
+            alert('Failed to load files');
+        }
+    }
+
+    async refreshDiffTree() {
+        const leftTree = this.leftZipHandler.getFileTree();
+        const rightTree = this.rightZipHandler.getFileTree();
+
+        const mergedTree = mergeFileTrees(leftTree, rightTree);
+        await computeDiffStatuses(mergedTree, this.leftZipHandler, this.rightZipHandler);
+
+        this.treeView.render(
+            mergedTree,
+            async (node) => {
+                await this.diffEditor.loadFile(node);
+            },
+            (node) => {
+                this.handleDelete(node);
+            }
+        );
+    }
+
+    handleDelete(node: MergedZipNode) {
+        const itemType = node.isDir ? '폴더' : '파일';
+        let message = `"${node.name}" ${itemType}을(를) 삭제하시겠습니까?`;
+
+        if (node.leftExists && node.rightExists) {
+            message += '\n\n양쪽 파일 모두 삭제됩니다.';
+        } else if (node.leftExists) {
+            message += '\n\n왼쪽 파일에서만 삭제됩니다.';
+        } else if (node.rightExists) {
+            message += '\n\n오른쪽 파일에서만 삭제됩니다.';
+        }
+
+        if (node.isDir) {
+            let leftCount = 0, rightCount = 0;
+            if (node.leftExists) {
+                leftCount = this.leftZipHandler.countFilesInFolder(node.path);
+            }
+            if (node.rightExists) {
+                rightCount = this.rightZipHandler.countFilesInFolder(node.path);
+            }
+
+            if (node.leftExists && node.rightExists) {
+                message = `"${node.name}" 폴더를 삭제하시겠습니까?\n(왼쪽: ${leftCount}개, 오른쪽: ${rightCount}개 파일 포함)\n\n양쪽 파일 모두 삭제됩니다.`;
+            } else if (node.leftExists) {
+                message = `"${node.name}" 폴더를 삭제하시겠습니까?\n(${leftCount}개 파일 포함)\n\n왼쪽 파일에서만 삭제됩니다.`;
+            } else if (node.rightExists) {
+                message = `"${node.name}" 폴더를 삭제하시겠습니까?\n(${rightCount}개 파일 포함)\n\n오른쪽 파일에서만 삭제됩니다.`;
+            }
+        }
+
+        message = this.addCriticalFileWarning(message, node.path, node.name);
+
+        if (confirm(message)) {
+            this.animateNodeDeletion(node.path);
+
+            this.waitForAnimation().then(async () => {
+                try {
+                    if (node.leftExists) {
+                        if (node.isDir) {
+                            this.leftZipHandler.deleteFolder(node.path);
+                        } else {
+                            this.leftZipHandler.deleteFile(node.path);
+                        }
+                    }
+
+                    if (node.rightExists) {
+                        if (node.isDir) {
+                            this.rightZipHandler.deleteFolder(node.path);
+                        } else {
+                            this.rightZipHandler.deleteFile(node.path);
+                        }
+                    }
+
+                    await this.refreshDiffTree();
+                    this.diffEditor.reset();
+                } catch (error) {
+                    console.error(error);
+                    alert('삭제 중 오류 발생');
+                }
+            });
+        }
+    }
+
+    async downloadLeftFile() {
+        if (!this.leftFileName) return;
+        try {
+            const blob = await this.leftZipHandler.generateZip('blob');
+            saveAs(blob, this.leftFileName);
+        } catch (error) {
+            console.error(error);
+            alert('Failed to generate left zip');
+        }
+    }
+
+    async downloadRightFile() {
+        if (!this.rightFileName) return;
+        try {
+            const blob = await this.rightZipHandler.generateZip('blob');
+            saveAs(blob, this.rightFileName);
+        } catch (error) {
+            console.error(error);
+            alert('Failed to generate right zip');
+        }
+    }
+
+    cleanup() {
+        this.diffEditor.cleanup();
+        this.leftFileName = '';
+        this.rightFileName = '';
+        this.leftFileNameDisplay.textContent = '';
+        this.rightFileNameDisplay.textContent = '';
+        this.downloadLeftBtn.disabled = true;
+        this.downloadRightBtn.disabled = true;
+        this.clearSidebarTree();
+    }
+}

--- a/src/modes/mode.ts
+++ b/src/modes/mode.ts
@@ -1,0 +1,109 @@
+import { ZipHandler, type ZipNode } from '../utils/zipHandler';
+import { BaseMode } from './baseMode';
+import { Editor } from '../ui/editor';
+import { saveAs } from 'file-saver';
+
+export class Mode extends BaseMode {
+    private zipHandler: ZipHandler;
+    private editor: Editor;
+    private currentFileName: string = '';
+
+    private fileNameDisplay: HTMLElement;
+    private downloadBtn: HTMLButtonElement;
+
+    constructor() {
+        super(false); // Not diff mode
+
+        this.zipHandler = new ZipHandler();
+        this.fileNameDisplay = document.getElementById('file-name')!;
+        this.downloadBtn = document.getElementById('btn-download') as HTMLButtonElement;
+
+        this.editor = new Editor(this.zipHandler, (path) => {
+            this.treeView.highlightTreeNode(path);
+        });
+
+        this.downloadBtn.addEventListener('click', () => this.downloadFile());
+    }
+
+    async handleFile(file: File) {
+        try {
+            await this.zipHandler.loadAsync(file);
+            this.currentFileName = file.name;
+            this.fileNameDisplay.textContent = `(${file.name})`;
+            this.downloadBtn.disabled = false;
+
+            this.refreshFileTree();
+            this.editor.reset();
+        } catch (error) {
+            console.error(error);
+            alert('Failed to load file');
+        }
+    }
+
+    refreshFileTree() {
+        const openFolders = this.saveOpenFolders();
+
+        const tree = this.zipHandler.getFileTree();
+        this.treeView.render(
+            tree,
+            async (node) => {
+                await this.editor.loadFile(node);
+            },
+            (node) => {
+                this.handleDelete(node);
+            }
+        );
+
+        this.restoreOpenFolders(openFolders);
+    }
+
+    handleDelete(node: ZipNode) {
+        const itemType = node.isDir ? '폴더' : '파일';
+        let message = `"${node.name}" ${itemType}을(를) 삭제하시겠습니까?`;
+
+        if (node.isDir) {
+            const fileCount = this.zipHandler.countFilesInFolder(node.path);
+            message = `"${node.name}" 폴더를 삭제하시겠습니까?\n(${fileCount}개 파일 포함)`;
+        }
+
+        message = this.addCriticalFileWarning(message, node.path, node.name);
+
+        if (confirm(message)) {
+            this.animateNodeDeletion(node.path);
+
+            this.waitForAnimation().then(() => {
+                if (node.isDir) {
+                    this.zipHandler.deleteFolder(node.path);
+                } else {
+                    this.zipHandler.deleteFile(node.path);
+                }
+
+                const currentPath = this.editor.getCurrentFilePath();
+                if (currentPath && (currentPath === node.path || currentPath.startsWith(node.path + '/'))) {
+                    this.editor.reset();
+                }
+
+                this.refreshFileTree();
+            });
+        }
+    }
+
+    async downloadFile() {
+        if (!this.currentFileName) return;
+        try {
+            const blob = await this.zipHandler.generateZip('blob');
+            saveAs(blob, this.currentFileName);
+        } catch (error) {
+            console.error(error);
+            alert('Failed to generate zip');
+        }
+    }
+
+    cleanup() {
+        this.editor.reset();
+        this.currentFileName = '';
+        this.fileNameDisplay.textContent = '';
+        this.downloadBtn.disabled = true;
+        this.clearSidebarTree();
+    }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -349,3 +349,183 @@ img.preview-image {
 .hidden {
     display: none !important;
 }
+
+/* ===== Diff Mode Styles ===== */
+
+/* Diff File Names in Header */
+#diff-file-names {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 16px;
+}
+
+.diff-file-label {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.diff-separator {
+    font-size: 16px;
+    color: var(--text-secondary);
+    font-weight: bold;
+    margin: 0 4px;
+}
+
+/* Diff Download Buttons */
+#diff-download-btns {
+    display: flex;
+    gap: 8px;
+}
+
+#btn-download-left {
+    background-color: #0891b2;
+    color: white;
+}
+
+#btn-download-left:hover:not(:disabled) {
+    background-color: #0e7490;
+}
+
+#btn-download-right {
+    background-color: #ea580c;
+    color: white;
+}
+
+#btn-download-right:hover:not(:disabled) {
+    background-color: #c2410c;
+}
+
+/* Diff Editor Container */
+#diff-editor-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.diff-editor-toolbar {
+    background-color: var(--bg-panel);
+    border-bottom: 1px solid var(--border-color);
+    padding: 8px 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 36px;
+}
+
+.diff-editor-toolbar span {
+    font-family: monospace;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.diff-editor-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    background-color: var(--bg-panel);
+    border-bottom: 1px solid var(--border-color);
+}
+
+#btn-save-left,
+#btn-save-right {
+    background-color: var(--accent-color);
+    color: white;
+    padding: 4px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#btn-save-left:hover:not(:disabled),
+#btn-save-right:hover:not(:disabled) {
+    background-color: var(--accent-hover);
+}
+
+#diff-editor-content {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Diff Tree Status Colors */
+.tree-content[data-status="left-only"] {
+    color: #60a5fa;
+}
+
+.tree-content[data-status="right-only"] {
+    color: #fb923c;
+}
+
+.tree-content[data-status="both-same"] {
+    color: #6b7280;
+}
+
+.tree-content[data-status="both-diff"] {
+    color: var(--text-secondary);
+}
+
+.tree-content[data-status="both-diff"].selected {
+    background-color: var(--accent-color);
+    color: white;
+}
+
+.tree-content[data-status="left-only"].selected,
+.tree-content[data-status="right-only"].selected,
+.tree-content[data-status="both-same"].selected {
+    background-color: var(--accent-color);
+    color: white;
+}
+
+/* Status icon in tree */
+.tree-status-icon {
+    margin-right: 4px;
+    font-size: 14px;
+}
+
+/* CodeMirror Merge View Overrides */
+.cm-mergeView {
+    height: 100%;
+    border: none;
+}
+
+.cm-mergeViewEditor {
+    height: 100%;
+}
+
+.cm-merge-revert {
+    display: none;
+}
+
+/* Search Panel in Diff Mode - 2 Line Layout */
+#diff-editor-content .cm-search {
+    flex-wrap: wrap;
+    max-width: 100%;
+}
+
+#diff-editor-content .cm-search > * {
+    flex-shrink: 0;
+}
+
+/* Ensure replace controls go to second line */
+#diff-editor-content .cm-search br {
+    display: block;
+    width: 100%;
+    height: 0;
+}
+
+/* Diff highlights for merge view */
+.cm-deletedLine {
+    background-color: rgba(255, 85, 85, 0.2) !important;
+}
+
+.cm-insertedLine {
+    background-color: rgba(85, 255, 85, 0.2) !important;
+}
+
+.cm-changedLine {
+    background-color: rgba(255, 255, 85, 0.15) !important;
+}

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -1,0 +1,14 @@
+export type AppMode = 'single' | 'diff';
+
+export interface MergedZipNode {
+    name: string;
+    path: string;
+    isDir: boolean;
+    status: DiffStatus;
+    children?: MergedZipNode[];
+    leftExists: boolean;
+    rightExists: boolean;
+    contentsMatch?: boolean; // only for files
+}
+
+export type DiffStatus = 'both-same' | 'both-diff' | 'left-only' | 'right-only';

--- a/src/ui/baseEditor.ts
+++ b/src/ui/baseEditor.ts
@@ -1,0 +1,155 @@
+import { ZipHandler } from '../utils/zipHandler';
+import xmlFormatter from 'xml-formatter';
+import { hoverTooltip } from "@codemirror/view";
+
+/**
+ * Base class for editors with common relationship handling
+ * Extracted from original Editor class
+ */
+export abstract class BaseEditor {
+    protected zipHandler: ZipHandler;
+    protected relsMap: Map<string, string> = new Map();
+    protected onHoverTarget: (path: string | null) => void;
+
+    constructor(zipHandler: ZipHandler, onHoverTarget: (path: string | null) => void) {
+        this.zipHandler = zipHandler;
+        this.onHoverTarget = onHoverTarget;
+    }
+
+    /**
+     * Load and parse .rels file for a given XML file
+     */
+    protected async loadRelsFile(xmlPath: string, targetMap: Map<string, string> = this.relsMap, zipHandler: ZipHandler = this.zipHandler): Promise<void> {
+        targetMap.clear();
+        const parts = xmlPath.split('/');
+        const fileName = parts.pop();
+        const folder = parts.join('/');
+
+        // Construct .rels path: folder/_rels/fileName.rels
+        const relsFolder = folder ? `${folder}/_rels` : '_rels';
+        const relsPath = `${relsFolder}/${fileName}.rels`;
+
+        try {
+            const content = await zipHandler.getFileContent(relsPath);
+            if (typeof content === 'string') {
+                this.parseRelsContent(content, folder, targetMap);
+            }
+        } catch (e) {
+            // .rels file might not exist, which is fine
+            console.log(`[Debug] No .rels file found for ${xmlPath}`);
+        }
+    }
+
+    /**
+     * Parse .rels XML content and extract relationships
+     */
+    protected parseRelsContent(content: string, folder: string, targetMap: Map<string, string> = this.relsMap): void {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(content, "text/xml");
+        const relationships = xmlDoc.getElementsByTagName("Relationship");
+
+        for (let i = 0; i < relationships.length; i++) {
+            const rel = relationships[i];
+            const id = rel.getAttribute("Id");
+            const target = rel.getAttribute("Target");
+
+            if (id && target) {
+                const resolvedPath = this.resolveRelativePath(target, folder);
+                targetMap.set(id, resolvedPath);
+            }
+        }
+        console.log(`[Debug] Loaded ${targetMap.size} relationships`, targetMap);
+    }
+
+    /**
+     * Resolve relative paths in relationship targets
+     */
+    protected resolveRelativePath(target: string, folder: string): string {
+        // Skip external URLs
+        if (target.startsWith('http') || target.includes(':')) {
+            return target;
+        }
+
+        // Handle absolute paths
+        if (target.startsWith('/')) {
+            return target.substring(1);
+        }
+
+        // Resolve relative paths
+        const currentDirParts = folder ? folder.split('/') : [];
+        const targetParts = target.split('/');
+
+        for (const part of targetParts) {
+            if (part === '..') {
+                currentDirParts.pop();
+            } else if (part !== '.') {
+                currentDirParts.push(part);
+            }
+        }
+
+        return currentDirParts.join('/');
+    }
+
+    /**
+     * Create relationship tooltip for rId references (uses this.relsMap)
+     */
+    protected createRelationshipTooltip() {
+        return this.createRelationshipTooltipWithMap(this.relsMap);
+    }
+
+    /**
+     * Create relationship tooltip with a specific relsMap
+     * Can be used by subclasses with multiple relsMaps
+     */
+    protected createRelationshipTooltipWithMap(relsMap: Map<string, string>) {
+        return hoverTooltip((view, pos) => {
+            const { from, to, text } = view.state.doc.lineAt(pos);
+            let start = pos, end = pos;
+            while (start > from && /\w/.test(text[start - from - 1])) start--;
+            while (end < to && /\w/.test(text[end - from])) end++;
+
+            if (start == end) return null;
+
+            const word = text.slice(start - from, end - from);
+            const target = relsMap.get(word);
+
+            if (target) {
+                console.log(`[Debug] Hovered: ${word}, Target: ${target}`);
+                return {
+                    pos: start,
+                    end,
+                    above: true,
+                    create: () => {
+                        this.onHoverTarget(target);
+                        const dom = document.createElement("div");
+                        dom.textContent = `Target: ${target}`;
+
+                        return {
+                            dom,
+                            destroy: () => {
+                                this.onHoverTarget(null);
+                            }
+                        };
+                    }
+                };
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Format XML content
+     */
+    protected formatXml(content: string): string {
+        try {
+            return xmlFormatter(content, {
+                indentation: '  ',
+                collapseContent: true,
+                lineSeparator: '\n'
+            });
+        } catch (e) {
+            // Return original if formatting fails
+            return content;
+        }
+    }
+}

--- a/src/ui/diffEditor.ts
+++ b/src/ui/diffEditor.ts
@@ -1,0 +1,312 @@
+import { ZipHandler } from '../utils/zipHandler';
+import type { MergedZipNode } from '../types/diff';
+import { BaseEditor } from './baseEditor';
+import { EditorView } from "@codemirror/view"
+import { MergeView } from "@codemirror/merge"
+import { getCommonExtensions } from '../lib/codemirror';
+import { FILE_EXTENSIONS } from '../const/constants';
+import { createElement } from '../utils/domUtils';
+import { openSearchPanel, closeSearchPanel, search } from "@codemirror/search";
+import { keymap } from "@codemirror/view";
+
+/**
+ * DiffEditor for comparing two files side-by-side
+ * Extends BaseEditor with MergeView and dual zipHandlers
+ */
+export class DiffEditor extends BaseEditor {
+    private contentArea: HTMLElement;
+    private pathDisplay: HTMLElement;
+    private saveLeftBtn: HTMLButtonElement;
+    private saveRightBtn: HTMLButtonElement;
+    private emptyState: HTMLElement;
+    private editorContainer: HTMLElement;
+
+    private currentNode: MergedZipNode | null = null;
+    private rightZipHandler: ZipHandler;
+    private mergeView: MergeView | null = null;
+    private leftEditor: EditorView | null = null;
+    private rightEditor: EditorView | null = null;
+    private rightRelsMap: Map<string, string> = new Map();
+
+    constructor(leftZipHandler: ZipHandler, rightZipHandler: ZipHandler, onHoverTarget: (path: string | null) => void) {
+        super(leftZipHandler, onHoverTarget);
+
+        this.rightZipHandler = rightZipHandler;
+
+        this.contentArea = document.getElementById('diff-editor-content')!;
+        this.pathDisplay = document.getElementById('diff-current-path')!;
+        this.saveLeftBtn = document.getElementById('btn-save-left') as HTMLButtonElement;
+        this.saveRightBtn = document.getElementById('btn-save-right') as HTMLButtonElement;
+        this.emptyState = document.getElementById('empty-state')!;
+        this.editorContainer = document.getElementById('diff-editor-container')!
+
+        this.saveLeftBtn.addEventListener('click', () => this.saveLeft());
+        this.saveRightBtn.addEventListener('click', () => this.saveRight());
+    }
+
+    async loadFile(node: MergedZipNode) {
+        this.currentNode = node;
+        this.emptyState.classList.add('hidden');
+        this.editorContainer.classList.remove('hidden');
+        this.contentArea.innerHTML = '';
+
+        this.pathDisplay.textContent = node.path;
+
+        this.saveLeftBtn.disabled = true;
+        this.saveRightBtn.disabled = true;
+
+        if (this.mergeView) {
+            this.mergeView.destroy();
+            this.mergeView = null;
+            this.leftEditor = null;
+            this.rightEditor = null;
+        }
+
+        try {
+            const isXmlFile = FILE_EXTENSIONS.XML.some(ext => node.name.endsWith(ext));
+
+            // Load relationship files if XML
+            if (isXmlFile) {
+                if (node.leftExists) {
+                    await this.loadRelsFile(node.path);
+                }
+                if (node.rightExists) {
+                    await this.loadRelsFile(node.path, this.rightRelsMap, this.rightZipHandler);
+                }
+            }
+
+            // Handle images
+            if (FILE_EXTENSIONS.IMAGE.some(ext => node.name.toLowerCase().endsWith(ext))) {
+                await this.showImageComparison(node);
+                return;
+            }
+
+            // Load and format content
+            const leftContent = await this.loadAndFormatContent(node, true, isXmlFile);
+            const rightContent = await this.loadAndFormatContent(node, false, isXmlFile);
+
+            this.contentArea.innerHTML = '';
+
+            if (typeof leftContent === 'string' || typeof rightContent === 'string') {
+                await this.createMergeView(leftContent, rightContent, node);
+            } else {
+                this.contentArea.innerHTML = '<div style="color: #9ca3af; text-align: center; margin-top: 20px;">Cannot compare binary files</div>';
+            }
+
+        } catch (error) {
+            console.error(error);
+            this.contentArea.innerHTML = '<div style="color: red; text-align: center; margin-top: 20px;">Error loading file</div>';
+        }
+    }
+
+    private async loadAndFormatContent(node: MergedZipNode, isLeft: boolean, isXmlFile: boolean): Promise<string> {
+        const exists = isLeft ? node.leftExists : node.rightExists;
+        if (!exists) return '';
+
+        const zipHandler = isLeft ? this.zipHandler : this.rightZipHandler;
+        const data = await zipHandler.getFileContent(node.path);
+
+        if (typeof data !== 'string') return '';
+
+        // Format XML using inherited method
+        if (isXmlFile) {
+            return this.formatXml(data);
+        }
+
+        return data;
+    }
+
+    private async showImageComparison(node: MergedZipNode) {
+        const container = createElement('div', {
+            style: {
+                display: 'flex',
+                height: '100%',
+                overflow: 'auto',
+                gap: '10px',
+                padding: '20px'
+            }
+        });
+
+        const leftContainer = await this.createImageContainer(node, true);
+        const rightContainer = await this.createImageContainer(node, false);
+
+        container.appendChild(leftContainer);
+        container.appendChild(rightContainer);
+        this.contentArea.appendChild(container);
+    }
+
+    private async createImageContainer(node: MergedZipNode, isLeft: boolean): Promise<HTMLDivElement> {
+        const container = createElement('div', {
+            style: {
+                flex: '1',
+                textAlign: 'center'
+            }
+        });
+
+        const exists = isLeft ? node.leftExists : node.rightExists;
+
+        if (exists) {
+            const zipHandler = isLeft ? this.zipHandler : this.rightZipHandler;
+            const data = await zipHandler.getFileContent(node.path);
+
+            if (data instanceof Blob) {
+                const url = URL.createObjectURL(data);
+                const img = createElement('img', {
+                    style: {
+                        maxWidth: '100%',
+                        height: 'auto'
+                    }
+                });
+                img.src = url;
+                container.appendChild(img);
+            }
+        } else {
+            container.innerHTML = '<div style="color: #9ca3af; margin-top: 20px;">File not found</div>';
+        }
+
+        return container;
+    }
+
+    private async createMergeView(leftContent: string, rightContent: string, node: MergedZipNode) {
+        const baseExtensions = getCommonExtensions({ excludeSearch: true });
+
+        const syncSearchAlignment = () => {
+            if (!this.leftEditor || !this.rightEditor) return;
+
+            const leftPanel = this.leftEditor.dom.querySelector('.cm-search');
+            const rightPanel = this.rightEditor.dom.querySelector('.cm-search');
+
+            this.leftEditor.dom.querySelector('.search-spacer')?.remove();
+            this.rightEditor.dom.querySelector('.search-spacer')?.remove();
+
+            if (leftPanel && !rightPanel) {
+                const spacer = createElement('div', {
+                    className: 'search-spacer',
+                    style: { height: `${leftPanel.getBoundingClientRect().height}px`, width: '100%' }
+                });
+                this.rightEditor.dom.insertBefore(spacer, this.rightEditor.dom.firstChild);
+            } else if (rightPanel && !leftPanel) {
+                const spacer = createElement('div', {
+                    className: 'search-spacer',
+                    style: { height: `${rightPanel.getBoundingClientRect().height}px`, width: '100%' }
+                });
+                this.leftEditor.dom.insertBefore(spacer, this.leftEditor.dom.firstChild);
+            }
+        };
+
+        const syncOpenSearch = () => {
+            if (this.leftEditor && this.rightEditor) {
+                openSearchPanel(this.leftEditor);
+                openSearchPanel(this.rightEditor);
+                setTimeout(syncSearchAlignment, 0);
+            }
+            return true;
+        };
+
+        const syncCloseSearch = () => {
+            if (this.leftEditor && this.rightEditor) {
+                closeSearchPanel(this.leftEditor);
+                closeSearchPanel(this.rightEditor);
+                setTimeout(syncSearchAlignment, 0);
+            }
+            return true;
+        };
+
+        const syncSearchKeymap = keymap.of([
+            { key: "Mod-f", run: syncOpenSearch },
+            { key: "Escape", run: syncCloseSearch }
+        ]);
+
+        // Create tooltips using inherited createRelationshipTooltipWithMap
+        const leftTooltip = this.createRelationshipTooltipWithMap(this.relsMap);
+        const rightTooltip = this.createRelationshipTooltipWithMap(this.rightRelsMap);
+
+        this.mergeView = new MergeView({
+            a: {
+                doc: leftContent,
+                extensions: [
+                    ...baseExtensions,
+                    search({ top: true }),
+                    syncSearchKeymap,
+                    leftTooltip,
+                    EditorView.updateListener.of((update) => {
+                        if (update.docChanged && node.leftExists) {
+                            this.saveLeftBtn.disabled = false;
+                        }
+                        setTimeout(syncSearchAlignment, 0);
+                    })
+                ]
+            },
+            b: {
+                doc: rightContent,
+                extensions: [
+                    ...baseExtensions,
+                    search({ top: true }),
+                    syncSearchKeymap,
+                    rightTooltip,
+                    EditorView.updateListener.of((update) => {
+                        if (update.docChanged && node.rightExists) {
+                            this.saveRightBtn.disabled = false;
+                        }
+                        setTimeout(syncSearchAlignment, 0);
+                    })
+                ]
+            },
+            parent: this.contentArea,
+            highlightChanges: true,
+            gutter: true
+        });
+
+        this.leftEditor = this.mergeView.a;
+        this.rightEditor = this.mergeView.b;
+
+        openSearchPanel(this.leftEditor);
+        openSearchPanel(this.rightEditor);
+
+        setTimeout(syncSearchAlignment, 100);
+    }
+
+    async saveLeft() {
+        if (!this.currentNode || !this.currentNode.leftExists || !this.leftEditor) return;
+
+        try {
+            const content = this.leftEditor.state.doc.toString();
+            await this.zipHandler.updateFile(this.currentNode.path, content);
+            this.saveLeftBtn.disabled = true;
+            alert('Left file saved internally!');
+        } catch (error) {
+            console.error(error);
+            alert('Failed to save left file');
+        }
+    }
+
+    async saveRight() {
+        if (!this.currentNode || !this.currentNode.rightExists || !this.rightEditor) return;
+
+        try {
+            const content = this.rightEditor.state.doc.toString();
+            await this.rightZipHandler.updateFile(this.currentNode.path, content);
+            this.saveRightBtn.disabled = true;
+            alert('Right file saved internally!');
+        } catch (error) {
+            console.error(error);
+            alert('Failed to save right file');
+        }
+    }
+
+    reset() {
+        this.currentNode = null;
+        if (this.mergeView) {
+            this.mergeView.destroy();
+            this.mergeView = null;
+        }
+        this.leftEditor = null;
+        this.rightEditor = null;
+        this.emptyState.classList.remove('hidden');
+        this.editorContainer.classList.add('hidden');
+    }
+
+    cleanup() {
+        this.reset();
+    }
+}

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -1,118 +1,17 @@
 import { ZipHandler, type ZipNode } from '../utils/zipHandler';
-import xmlFormatter from 'xml-formatter';
-import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightActiveLine, hoverTooltip } from "@codemirror/view"
+import { BaseEditor } from './baseEditor';
+import { EditorView, keymap } from "@codemirror/view"
 import { EditorState } from "@codemirror/state"
-import { foldGutter, indentOnInput, syntaxHighlighting, bracketMatching, foldKeymap, defaultHighlightStyle, HighlightStyle } from "@codemirror/language"
-import { history, defaultKeymap, historyKeymap } from "@codemirror/commands"
-import { searchKeymap, highlightSelectionMatches, search, getSearchQuery, openSearchPanel } from "@codemirror/search"
-import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete"
-import { lintKeymap } from "@codemirror/lint"
-import { xml } from "@codemirror/lang-xml"
-import { tags as t } from "@lezer/highlight"
+import { highlightSelectionMatches, getSearchQuery, openSearchPanel } from "@codemirror/search"
+import { rectangularSelection, crosshairCursor } from "@codemirror/view"
+import { getCommonExtensions } from '../lib/codemirror';
+import { DESKTOP_MIN_WIDTH, FILE_EXTENSIONS } from '../const/constants';
 
-// Custom Theme
-const myTheme = EditorView.theme({
-    "&": {
-        color: "#e0e0e0",
-        backgroundColor: "#1e1e1e",
-        height: "100%",
-        fontSize: "14px",
-        fontFamily: "'Menlo', 'Consolas', 'Monaco', 'Liberation Mono', 'Lucida Console', monospace"
-    },
-    ".cm-foldPlaceholder": {
-        backgroundColor: "transparent",
-        border: "none",
-        color: "#e0e0e0"
-    },
-    ".cm-content": {
-        caretColor: "#aeafad"
-    },
-    "&.cm-focused .cm-cursor": {
-        borderLeftColor: "#aeafad"
-    },
-    "&.cm-focused .cm-selectionBackground, ::selection": {
-        backgroundColor: "#3E4451"
-    },
-    ".cm-gutters": {
-        backgroundColor: "#1e1e1e",
-        color: "#5c6370",
-        border: "none"
-    },
-    // Search Panel Styles
-    ".cm-search": {
-        backgroundColor: "#2c313a",
-        color: "#ffffff",
-        border: "1px solid #4b5563",
-        borderRadius: "6px",
-        padding: "6px 12px",
-        fontWeight: "bold",
-        fontSize: "15px",
-        display: "flex",
-        alignItems: "center",
-        flexWrap: "wrap",
-        gap: "8px",
-        maxWidth: "100%"
-    },
-    ".cm-search input:not([type='checkbox'])": {
-        backgroundColor: "#1f2937",
-        color: "#e0e0e0",
-        border: "1px solid #4b5563",
-        borderRadius: "4px",
-        padding: "6px 10px",
-        fontSize: "15px",
-        minWidth: "200px"
-    },
-    ".cm-search button": {
-        color: "#e0e0e0",
-        cursor: "pointer",
-        fontWeight: "bold",
-        padding: "4px 8px",
-        fontSize: "13px",
-        backgroundColor: "#374151",
-        border: "1px solid #4b5563",
-        borderRadius: "4px",
-        textTransform: "capitalize"
-    },
-    ".cm-search button:hover": {
-        backgroundColor: "#4b5563"
-    },
-    ".cm-search label": {
-        color: "#e0e0e0",
-        fontWeight: "bold",
-        fontSize: "13px",
-        display: "inline-flex",
-        alignItems: "center",
-        gap: "4px",
-        whiteSpace: "nowrap",
-        cursor: "pointer"
-    },
-    ".cm-search input[type='checkbox']": {
-        margin: "0",
-        cursor: "pointer"
-    },
-    // Tooltip Styles
-    ".cm-tooltip": {
-        backgroundColor: "#2c313a",
-        color: "#e0e0e0",
-        border: "1px solid #4b5563",
-        borderRadius: "4px",
-        padding: "4px 8px",
-        fontSize: "12px",
-        zIndex: "100"
-    }
-}, { dark: true })
-
-const myHighlightStyle = HighlightStyle.define([
-    { tag: t.angleBracket, color: "#e02275" },
-    { tag: t.tagName, color: "#e06275" },
-    { tag: t.attributeName, color: "#98c379" },
-    { tag: t.attributeValue, color: "#e5c07b" },
-    { tag: t.string, color: "#e5c07b" },
-    { tag: t.comment, color: "#5c6370", fontStyle: "italic" },
-    { tag: t.content, color: "#abb2bf" }
-])
-
-export class Editor {
+/**
+ * Editor for single file mode
+ * Extends BaseEditor with single EditorView
+ */
+export class Editor extends BaseEditor {
     private contentArea: HTMLElement;
     private pathDisplay: HTMLElement;
     private saveBtn: HTMLButtonElement;
@@ -120,114 +19,19 @@ export class Editor {
     private editorContainer: HTMLElement;
 
     private currentNode: ZipNode | null = null;
-    private zipHandler: ZipHandler;
     private editorView: EditorView | null = null;
-    private relsMap: Map<string, string> = new Map();
-    private onHoverTarget: (path: string | null) => void;
 
     constructor(zipHandler: ZipHandler, onHoverTarget: (path: string | null) => void) {
+        super(zipHandler, onHoverTarget);
+
         this.contentArea = document.getElementById('editor-content')!;
         this.pathDisplay = document.getElementById('current-path')!;
         this.saveBtn = document.getElementById('btn-save') as HTMLButtonElement;
         this.emptyState = document.getElementById('empty-state')!;
         this.editorContainer = document.getElementById('editor-container')!;
-        this.zipHandler = zipHandler;
-        this.onHoverTarget = onHoverTarget;
 
         this.saveBtn.addEventListener('click', () => this.save());
     }
-
-    private async loadRelsFile(xmlPath: string) {
-        this.relsMap.clear();
-        const parts = xmlPath.split('/');
-        const fileName = parts.pop();
-        const folder = parts.join('/');
-
-        // Construct .rels path: folder/_rels/fileName.rels
-        // If file is at root, folder is empty string
-        const relsFolder = folder ? `${folder}/_rels` : '_rels';
-        const relsPath = `${relsFolder}/${fileName}.rels`;
-
-        try {
-            const content = await this.zipHandler.getFileContent(relsPath);
-            if (typeof content === 'string') {
-                const parser = new DOMParser();
-                const xmlDoc = parser.parseFromString(content, "text/xml");
-                const relationships = xmlDoc.getElementsByTagName("Relationship");
-
-                for (let i = 0; i < relationships.length; i++) {
-                    const rel = relationships[i];
-                    const id = rel.getAttribute("Id");
-                    const target = rel.getAttribute("Target");
-
-                    if (id && target) {
-                        let resolvedPath = target;
-
-                        // Resolve relative paths
-                        if (!target.startsWith('/') && !target.startsWith('http') && !target.includes(':')) {
-                            const currentDirParts = folder ? folder.split('/') : [];
-                            const targetParts = target.split('/');
-
-                            for (const part of targetParts) {
-                                if (part === '..') {
-                                    currentDirParts.pop();
-                                } else if (part !== '.') {
-                                    currentDirParts.push(part);
-                                }
-                            }
-                            resolvedPath = currentDirParts.join('/');
-                        }
-
-                        // Remove leading slash if present
-                        if (resolvedPath.startsWith('/')) {
-                            resolvedPath = resolvedPath.substring(1);
-                        }
-
-                        this.relsMap.set(id, resolvedPath);
-                    }
-                }
-                console.log(`[Debug] Loaded ${this.relsMap.size} relationships from ${relsPath}`, this.relsMap);
-            }
-        } catch (e) {
-            // .rels file might not exist, which is fine
-            console.log(`[Debug] No .rels file found for ${xmlPath}`);
-        }
-    }
-
-    private relationshipTooltip = hoverTooltip((view, pos) => {
-        const { from, to, text } = view.state.doc.lineAt(pos);
-        let start = pos, end = pos;
-        while (start > from && /\w/.test(text[start - from - 1])) start--;
-        while (end < to && /\w/.test(text[end - from])) end++;
-
-        if (start == end) return null;
-
-        const word = text.slice(start - from, end - from);
-        const target = this.relsMap.get(word);
-
-        if (target) {
-            console.log(`[Debug] Hovered: ${word}, Target: ${target}`);
-            return {
-                pos: start,
-                end,
-                above: true,
-                create: () => {
-                    this.onHoverTarget(target);
-                    const dom = document.createElement("div");
-                    dom.textContent = `Target: ${target}`;
-
-                    // Return an object with dom and destroy method
-                    return {
-                        dom,
-                        destroy: () => {
-                            this.onHoverTarget(null);
-                        }
-                    };
-                }
-            };
-        }
-        return null;
-    });
 
     async loadFile(node: ZipNode) {
         this.currentNode = node;
@@ -243,130 +47,78 @@ export class Editor {
         }
 
         try {
+            const isXmlFile = FILE_EXTENSIONS.XML.some(ext => node.name.endsWith(ext));
+
             // Load relationships if it's an XML file
-            if (node.name.endsWith('.xml')) {
+            if (isXmlFile) {
                 await this.loadRelsFile(node.path);
             }
 
             const data = await this.zipHandler.getFileContent(node.path);
-
             this.contentArea.innerHTML = '';
 
             if (typeof data === 'string') {
-                let displayContent = data;
-                try {
-                    if (node.name.endsWith('.xml') || node.name.endsWith('.rels')) {
-                        displayContent = xmlFormatter(data, {
-                            indentation: '  ',
-                            collapseContent: true,
-                            lineSeparator: '\n'
-                        });
-                    }
-                } catch (e) {
-                    // Ignore format error
-                }
-
-                const startState = EditorState.create({
-                    doc: displayContent,
-                    extensions: [
-                        lineNumbers(),
-                        highlightActiveLineGutter(),
-                        highlightSpecialChars(),
-                        history(),
-                        // Custom Fold Gutter
-                        foldGutter({
-                            markerDOM: (open) => {
-                                const span = document.createElement("span");
-                                span.style.cursor = "pointer";
-                                span.style.display = "flex";
-                                span.style.alignItems = "center";
-                                span.style.justifyContent = "center";
-                                span.style.width = "16px"; // Increased width
-                                span.style.height = "100%";
-
-                                const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-                                svg.setAttribute("width", "17"); // Increased size
-                                svg.setAttribute("height", "17"); // Increased size
-                                svg.setAttribute("viewBox", "0 0 20 20");
-                                svg.setAttribute("fill", "#9ca3af");
-
-                                if (open) {
-                                    // Down Arrow
-                                    svg.innerHTML = '<path d="M7 10l5 5 5-5z" />';
-                                } else {
-                                    // Right Arrow
-                                    svg.innerHTML = '<path d="M10 17l5-5-5-5z" />';
-                                }
-
-                                span.appendChild(svg);
-                                return span;
-                            }
-                        }),
-                        drawSelection(),
-                        dropCursor(),
-                        EditorState.allowMultipleSelections.of(true),
-                        indentOnInput(),
-                        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-                        bracketMatching(),
-                        closeBrackets(),
-                        autocompletion(),
-                        rectangularSelection(),
-                        crosshairCursor(),
-                        highlightActiveLine(),
-                        highlightSelectionMatches(),
-                        search({ top: true }), // Enable search panel with match count
-                        this.relationshipTooltip, // Add tooltip extension
-                        keymap.of([
-                            ...closeBracketsKeymap,
-                            ...defaultKeymap,
-                            ...searchKeymap,
-                            ...historyKeymap,
-                            ...foldKeymap,
-                            ...completionKeymap,
-                            ...lintKeymap,
-                            // Save Shortcut
-                            {
-                                key: "Mod-s",
-                                run: () => {
-                                    this.save();
-                                    return true;
-                                }
-                            }
-                        ]),
-                        xml(),
-                        myTheme,
-                        syntaxHighlighting(myHighlightStyle),
-                        EditorView.updateListener.of((update) => {
-                            if (update.docChanged) {
-                                this.saveBtn.disabled = false;
-                            }
-                            this.updateSearchCount(update.view);
-                        })
-                    ]
-                });
-
-                this.editorView = new EditorView({
-                    state: startState,
-                    parent: this.contentArea
-                });
-
-                // 검색 패널을 항상 표시 (모바일 제외)
-                // 768px 이상일 때만 자동으로 검색 패널 열기
-                if (window.innerWidth > 768) {
-                    openSearchPanel(this.editorView);
-                }
-
+                await this.loadTextFile(data, isXmlFile);
             } else {
-                const url = URL.createObjectURL(data);
-                const img = document.createElement('img');
-                img.src = url;
-                img.className = 'preview-image';
-                this.contentArea.appendChild(img);
+                this.loadImageFile(data);
             }
         } catch (error) {
             console.error(error);
             this.contentArea.innerHTML = '<div style="color: red; text-align: center; margin-top: 20px;">Error loading file</div>';
         }
+    }
+
+    private async loadTextFile(content: string, isXmlFile: boolean) {
+        let displayContent = content;
+
+        // Format XML
+        if (isXmlFile) {
+            displayContent = this.formatXml(content);
+        }
+
+        const startState = EditorState.create({
+            doc: displayContent,
+            extensions: [
+                ...getCommonExtensions(),
+                highlightSelectionMatches(),
+                rectangularSelection(),
+                crosshairCursor(),
+                this.createRelationshipTooltip(),
+                keymap.of([
+                    {
+                        key: "Mod-s",
+                        run: () => {
+                            this.save();
+                            return true;
+                        }
+                    }
+                ]),
+                EditorView.updateListener.of((update) => {
+                    if (update.docChanged) {
+                        this.saveBtn.disabled = false;
+                    }
+                    this.updateSearchCount(update.view);
+                })
+            ]
+        });
+
+        this.editorView = new EditorView({
+            state: startState,
+            parent: this.contentArea
+        });
+
+        // Open search panel on desktop
+        if (window.innerWidth > DESKTOP_MIN_WIDTH) {
+            openSearchPanel(this.editorView);
+        }
+    }
+
+    private loadImageFile(data: Blob) {
+        const url = URL.createObjectURL(data);
+        const img = document.createElement('img');
+        img.src = url;
+        img.className = 'preview-image';
+        this.contentArea.appendChild(img);
     }
 
     private updateSearchCount(view: EditorView) {
@@ -377,27 +129,7 @@ export class Editor {
 
         let countSpan = panel.querySelector('.cm-search-count') as HTMLElement;
         if (!countSpan) {
-            countSpan = document.createElement('span');
-            countSpan.className = 'cm-search-count';
-            countSpan.style.marginLeft = '8px';
-            countSpan.style.fontWeight = 'bold';
-            countSpan.style.color = '#60a5fa';
-            countSpan.style.fontSize = '14px';
-            countSpan.style.padding = '4px 8px';
-            countSpan.style.backgroundColor = '#1f2937';
-            countSpan.style.borderRadius = '4px';
-            countSpan.style.border = '1px solid #4b5563';
-            countSpan.style.minWidth = '110px';
-            countSpan.style.textAlign = 'center';
-            countSpan.style.display = 'inline-block';
-
-            // Insert after the first input (search input)
-            const searchInput = panel.querySelector('input:not([type="checkbox"])');
-            if (searchInput && searchInput.parentNode) {
-                searchInput.parentNode.insertBefore(countSpan, searchInput.nextSibling);
-            } else {
-                panel.appendChild(countSpan);
-            }
+            countSpan = this.createSearchCountElement(panel);
         }
 
         if (!query.search) {
@@ -421,16 +153,35 @@ export class Editor {
         countSpan.style.display = 'inline-block';
     }
 
-    async save() {
-        if (!this.currentNode) return;
+    private createSearchCountElement(panel: Element): HTMLElement {
+        const countSpan = document.createElement('span');
+        countSpan.className = 'cm-search-count';
+        countSpan.style.marginLeft = '8px';
+        countSpan.style.fontWeight = 'bold';
+        countSpan.style.color = '#60a5fa';
+        countSpan.style.fontSize = '14px';
+        countSpan.style.padding = '4px 8px';
+        countSpan.style.backgroundColor = '#1f2937';
+        countSpan.style.borderRadius = '4px';
+        countSpan.style.border = '1px solid #4b5563';
+        countSpan.style.minWidth = '110px';
+        countSpan.style.textAlign = 'center';
+        countSpan.style.display = 'inline-block';
 
-        let contentToSave: string | null = null;
-
-        if (this.editorView) {
-            contentToSave = this.editorView.state.doc.toString();
+        const searchInput = panel.querySelector('input:not([type="checkbox"])');
+        if (searchInput && searchInput.parentNode) {
+            searchInput.parentNode.insertBefore(countSpan, searchInput.nextSibling);
+        } else {
+            panel.appendChild(countSpan);
         }
 
-        if (contentToSave === null) return;
+        return countSpan;
+    }
+
+    async save() {
+        if (!this.currentNode || !this.editorView) return;
+
+        const contentToSave = this.editorView.state.doc.toString();
 
         try {
             await this.zipHandler.updateFile(this.currentNode.path, contentToSave);

--- a/src/ui/treeView.ts
+++ b/src/ui/treeView.ts
@@ -1,220 +1,256 @@
 import type { ZipNode } from '../utils/zipHandler';
+import type { MergedZipNode } from '../types/diff';
+import { getDiffStatusIcon } from '../utils/diffUtils';
 
-function createDeleteButton(node: ZipNode, onDelete: (node: ZipNode) => void): HTMLButtonElement {
-    const deleteBtn = document.createElement('button');
-    deleteBtn.className = 'tree-delete-btn';
-    deleteBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>`;
-    deleteBtn.style.padding = '2px 4px';
-    deleteBtn.style.marginLeft = '8px';
-    deleteBtn.style.background = 'transparent';
-    deleteBtn.style.border = 'none';
-    deleteBtn.style.cursor = 'pointer';
-    deleteBtn.style.color = '#9ca3af';
-    deleteBtn.style.display = 'none';
-    deleteBtn.style.flexShrink = '0';
-    deleteBtn.title = 'Delete';
+/**
+ * TreeView class for rendering file tree
+ * Supports both single mode and diff mode
+ */
+export class TreeView {
+    protected container: HTMLElement;
+    private isDiffMode: boolean;
 
-    deleteBtn.addEventListener('mouseenter', () => {
-        deleteBtn.style.color = '#ef4444';
-    });
-    deleteBtn.addEventListener('mouseleave', () => {
-        deleteBtn.style.color = '#9ca3af';
-    });
-    deleteBtn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onDelete(node);
-    });
-
-    return deleteBtn;
-}
-
-export function renderFileTree(
-    container: HTMLElement,
-    nodes: ZipNode[],
-    onSelect: (node: ZipNode) => void,
-    onDelete: (node: ZipNode) => void,
-    selectedPath?: string
-) {
-    container.innerHTML = '';
-    const ul = document.createElement('ul');
-    ul.style.paddingLeft = '0';
-
-    nodes.forEach(node => {
-        ul.appendChild(createTreeNode(node, onSelect, onDelete, selectedPath, 0));
-    });
-
-    container.appendChild(ul);
-}
-
-export function highlightTreeNode(container: HTMLElement, path: string | null) {
-    if (path) console.log(`[Debug] highlightTreeNode called with path: ${path}`);
-    // Remove existing highlights
-    const highlighted = container.querySelectorAll('.tree-content.hover-highlight');
-    highlighted.forEach(el => el.classList.remove('hover-highlight'));
-
-    if (path) {
-        // Add new highlight
-        const safePath = path.replace(/"/g, '\\"');
-        let target = container.querySelector(`.tree-content[data-path="${safePath}"]`);
-
-        // Try alternative path (add/remove leading slash) if not found
-        if (!target) {
-            const altPath = safePath.startsWith('/') ? safePath.substring(1) : `/${safePath}`;
-            target = container.querySelector(`.tree-content[data-path="${altPath}"]`);
-        }
-
-        if (target) {
-            target.classList.add('hover-highlight');
-
-            // Expand parent folders
-            let parent = target.parentElement; // li
-            while (parent) {
-                if (parent.tagName === 'UL' && parent.classList.contains('tree-children')) {
-                    parent.classList.add('open');
-                    // Update toggle icon of the parent li
-                    const parentLi = parent.parentElement;
-                    if (parentLi) {
-                        const toggle = parentLi.querySelector('.tree-toggle') as HTMLElement;
-                        const icon = parentLi.querySelector('.tree-icon') as HTMLElement;
-                        if (toggle) toggle.style.transform = 'rotate(90deg)';
-                        if (icon) icon.textContent = '📂';
-                    }
-                }
-                parent = parent.parentElement;
-                if (parent === container) break;
-            }
-
-            target.scrollIntoView({ block: 'nearest' });
-        } else {
-            console.log(`[Debug] Target element not found for path: ${path}`);
-        }
-    }
-}
-
-function createTreeNode(
-    node: ZipNode,
-    onSelect: (node: ZipNode) => void,
-    onDelete: (node: ZipNode) => void,
-    selectedPath: string | undefined,
-    level: number
-): HTMLElement {
-    const li = document.createElement('li');
-
-    // Node Content
-    const content = document.createElement('div');
-    content.className = 'tree-content';
-    content.setAttribute('data-path', node.path);
-    content.style.paddingLeft = `${level * 12 + 8}px`;
-    content.style.display = 'flex';
-    content.style.alignItems = 'center';
-
-    if (selectedPath === node.path) {
-        content.classList.add('selected');
+    constructor(container: HTMLElement, isDiffMode: boolean = false) {
+        this.container = container;
+        this.isDiffMode = isDiffMode;
     }
 
-    // Left side container (toggle + icon + label)
-    const leftContainer = document.createElement('div');
-    leftContainer.style.display = 'flex';
-    leftContainer.style.alignItems = 'center';
-    leftContainer.style.flex = '1';
-    leftContainer.style.minWidth = '0';
+    /**
+     * Render the file tree
+     */
+    render<T extends ZipNode | MergedZipNode>(
+        nodes: T[],
+        onSelect: (node: T) => void,
+        onDelete: (node: T) => void,
+        selectedPath?: string
+    ) {
+        this.container.innerHTML = '';
+        const ul = document.createElement('ul');
+        ul.style.paddingLeft = '0';
 
-    // Toggle Icon (Triangle)
-    const toggle = document.createElement('span');
-    toggle.className = 'tree-toggle';
-    toggle.style.display = 'inline-block';
-    toggle.style.width = '16px';
-    toggle.style.textAlign = 'center';
-    toggle.style.marginRight = '4px';
-    toggle.style.transition = 'transform 0.1s';
-
-    if (node.isDir) {
-        toggle.textContent = '▶';
-        toggle.style.fontSize = '10px';
-        toggle.style.color = '#9ca3af';
-    } else {
-        toggle.innerHTML = '&nbsp;';
-    }
-    leftContainer.appendChild(toggle);
-
-    // File/Folder Icon
-    const icon = document.createElement('span');
-    icon.className = 'tree-icon';
-    const iconData = getIcon(node);
-    if (iconData.type === 'svg') {
-        icon.innerHTML = iconData.content;
-    } else {
-        icon.textContent = iconData.content;
-    }
-    leftContainer.appendChild(icon);
-
-    // Label
-    const label = document.createElement('span');
-    label.className = 'tree-label';
-    label.textContent = node.name;
-    label.style.flex = '1';
-    label.style.minWidth = '0';
-    label.style.overflow = 'hidden';
-    label.style.textOverflow = 'ellipsis';
-    label.style.whiteSpace = 'nowrap';
-    leftContainer.appendChild(label);
-
-    content.appendChild(leftContainer);
-
-    // Delete Button
-    const deleteBtn = createDeleteButton(node, onDelete);
-    content.appendChild(deleteBtn);
-
-    // Show delete button on hover
-    content.addEventListener('mouseenter', () => {
-        deleteBtn.style.display = 'inline-block';
-    });
-    content.addEventListener('mouseleave', () => {
-        deleteBtn.style.display = 'none';
-    });
-
-    li.appendChild(content);
-
-    // Children Container
-    let childrenContainer: HTMLElement | null = null;
-    if (node.isDir && node.children) {
-        childrenContainer = document.createElement('ul');
-        childrenContainer.className = 'tree-children';
-        node.children.forEach(child => {
-            childrenContainer!.appendChild(createTreeNode(child, onSelect, onDelete, selectedPath, level + 1));
+        nodes.forEach(node => {
+            ul.appendChild(this.createTreeNode(node, onSelect, onDelete, selectedPath, 0));
         });
-        li.appendChild(childrenContainer);
+
+        this.container.appendChild(ul);
     }
 
-    // Event Handling
-    content.addEventListener('click', (e) => {
-        e.stopPropagation();
-        if (node.isDir) {
-            if (childrenContainer) {
-                childrenContainer.classList.toggle('open');
-                const isOpen = childrenContainer.classList.contains('open');
-                toggle.style.transform = isOpen ? 'rotate(90deg)' : 'rotate(0deg)';
-                icon.textContent = isOpen ? '📂' : '📁';
+    /**
+     * Highlight a specific node in the tree by path
+     */
+    highlightTreeNode(path: string | null) {
+        if (path) console.log(`[Debug] highlightTreeNode called with path: ${path}`);
+
+        const highlighted = this.container.querySelectorAll('.tree-content.hover-highlight');
+        highlighted.forEach(el => el.classList.remove('hover-highlight'));
+
+        if (path) {
+            const safePath = path.replace(/"/g, '\\"');
+            let target = this.container.querySelector(`.tree-content[data-path="${safePath}"]`);
+
+            if (!target) {
+                const altPath = safePath.startsWith('/') ? safePath.substring(1) : `/${safePath}`;
+                target = this.container.querySelector(`.tree-content[data-path="${altPath}"]`);
             }
-        } else {
-            // Deselect previous
-            const prevSelected = document.querySelector('.tree-content.selected');
-            if (prevSelected) prevSelected.classList.remove('selected');
 
-            content.classList.add('selected');
-            onSelect(node);
+            if (target) {
+                target.classList.add('hover-highlight');
+
+                let parent = target.parentElement;
+                while (parent) {
+                    if (parent.tagName === 'UL' && parent.classList.contains('tree-children')) {
+                        parent.classList.add('open');
+                        const parentLi = parent.parentElement;
+                        if (parentLi) {
+                            const toggle = parentLi.querySelector('.tree-toggle') as HTMLElement;
+                            const icon = parentLi.querySelector('.tree-icon') as HTMLElement;
+                            if (toggle) toggle.style.transform = 'rotate(90deg)';
+                            if (icon) icon.textContent = '📂';
+                        }
+                    }
+                    parent = parent.parentElement;
+                    if (parent === this.container) break;
+                }
+
+                target.scrollIntoView({ block: 'nearest' });
+            } else {
+                console.log(`[Debug] Target element not found for path: ${path}`);
+            }
         }
-    });
+    }
 
-    return li;
-}
+    /**
+     * Create a tree node element
+     */
+    protected createTreeNode<T extends ZipNode | MergedZipNode>(
+        node: T,
+        onSelect: (node: T) => void,
+        onDelete: (node: T) => void,
+        selectedPath: string | undefined,
+        level: number
+    ): HTMLElement {
+        const li = document.createElement('li');
 
-function getIcon(node: ZipNode): { type: 'text' | 'svg', content: string } {
-    if (node.isDir) return { type: 'text', content: '📁' };
-    if (node.name.endsWith('.xml')) return {
-        type: 'svg',
-        content: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#e06c75" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><path d="m9 15 3 3 3-3"/><path d="M12 12v6"/></svg>`
-    }; // Reddish file icon
-    if (node.name.match(/\.(png|jpg|jpeg|gif)$/i)) return { type: 'text', content: '🖼️' };
-    return { type: 'text', content: '📄' };
+        const content = document.createElement('div');
+        content.className = 'tree-content';
+        content.setAttribute('data-path', node.path);
+
+        // Add data-status for diff mode
+        if (this.isDiffMode && 'status' in node) {
+            content.setAttribute('data-status', (node as MergedZipNode).status);
+        }
+
+        content.style.paddingLeft = `${level * 12 + 8}px`;
+        content.style.display = 'flex';
+        content.style.alignItems = 'center';
+
+        if (selectedPath === node.path) {
+            content.classList.add('selected');
+        }
+
+        const leftContainer = document.createElement('div');
+        leftContainer.style.display = 'flex';
+        leftContainer.style.alignItems = 'center';
+        leftContainer.style.flex = '1';
+        leftContainer.style.minWidth = '0';
+
+        // Toggle Icon
+        const toggle = document.createElement('span');
+        toggle.className = 'tree-toggle';
+        toggle.style.display = 'inline-block';
+        toggle.style.width = '16px';
+        toggle.style.textAlign = 'center';
+        toggle.style.marginRight = '4px';
+        toggle.style.transition = 'transform 0.1s';
+
+        if (node.isDir) {
+            toggle.textContent = '▶';
+            toggle.style.fontSize = '10px';
+            toggle.style.color = '#9ca3af';
+        } else {
+            toggle.innerHTML = '&nbsp;';
+        }
+        leftContainer.appendChild(toggle);
+
+        // Diff Status Icon (only in diff mode)
+        if (this.isDiffMode && 'status' in node) {
+            const statusIcon = document.createElement('span');
+            statusIcon.className = 'tree-status-icon';
+            statusIcon.innerHTML = getDiffStatusIcon((node as MergedZipNode).status);
+            statusIcon.style.display = 'inline-flex';
+            statusIcon.style.alignItems = 'center';
+            statusIcon.style.marginRight = '4px';
+            leftContainer.appendChild(statusIcon);
+        }
+
+        // File/Folder Icon
+        const icon = document.createElement('span');
+        icon.className = 'tree-icon';
+        const iconData = this.getIcon(node);
+        if (iconData.type === 'svg') {
+            icon.innerHTML = iconData.content;
+        } else {
+            icon.textContent = iconData.content;
+        }
+        leftContainer.appendChild(icon);
+
+        // Label
+        const label = document.createElement('span');
+        label.className = 'tree-label';
+        label.textContent = node.name;
+        label.style.flex = '1';
+        label.style.minWidth = '0';
+        label.style.overflow = 'hidden';
+        label.style.textOverflow = 'ellipsis';
+        label.style.whiteSpace = 'nowrap';
+        leftContainer.appendChild(label);
+
+        content.appendChild(leftContainer);
+
+        // Delete Button
+        const deleteBtn = this.createDeleteButton(node, onDelete);
+        content.appendChild(deleteBtn);
+
+        content.addEventListener('mouseenter', () => {
+            deleteBtn.style.display = 'inline-block';
+        });
+        content.addEventListener('mouseleave', () => {
+            deleteBtn.style.display = 'none';
+        });
+
+        li.appendChild(content);
+
+        // Children Container
+        let childrenContainer: HTMLElement | null = null;
+        if (node.isDir && node.children) {
+            childrenContainer = document.createElement('ul');
+            childrenContainer.className = 'tree-children';
+            node.children.forEach(child => {
+                childrenContainer!.appendChild(this.createTreeNode(child as T, onSelect, onDelete, selectedPath, level + 1));
+            });
+            li.appendChild(childrenContainer);
+        }
+
+        // Event Handling
+        content.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (node.isDir) {
+                if (childrenContainer) {
+                    childrenContainer.classList.toggle('open');
+                    const isOpen = childrenContainer.classList.contains('open');
+                    toggle.style.transform = isOpen ? 'rotate(90deg)' : 'rotate(0deg)';
+                    icon.textContent = isOpen ? '📂' : '📁';
+                }
+            } else {
+                const prevSelected = document.querySelector('.tree-content.selected');
+                if (prevSelected) prevSelected.classList.remove('selected');
+
+                content.classList.add('selected');
+                onSelect(node);
+            }
+        });
+
+        return li;
+    }
+
+    protected createDeleteButton<T extends ZipNode | MergedZipNode>(
+        node: T,
+        onDelete: (node: T) => void
+    ): HTMLButtonElement {
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'tree-delete-btn';
+        deleteBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>`;
+        deleteBtn.style.padding = '2px 4px';
+        deleteBtn.style.marginLeft = '8px';
+        deleteBtn.style.background = 'transparent';
+        deleteBtn.style.border = 'none';
+        deleteBtn.style.cursor = 'pointer';
+        deleteBtn.style.color = '#9ca3af';
+        deleteBtn.style.display = 'none';
+        deleteBtn.style.flexShrink = '0';
+        deleteBtn.title = 'Delete';
+
+        deleteBtn.addEventListener('mouseenter', () => {
+            deleteBtn.style.color = '#ef4444';
+        });
+        deleteBtn.addEventListener('mouseleave', () => {
+            deleteBtn.style.color = '#9ca3af';
+        });
+        deleteBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            onDelete(node);
+        });
+
+        return deleteBtn;
+    }
+
+    protected getIcon(node: ZipNode): { type: 'text' | 'svg', content: string } {
+        if (node.isDir) return { type: 'text', content: '📁' };
+        if (node.name.endsWith('.xml')) return {
+            type: 'svg',
+            content: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#e06c75" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><path d="m9 15 3 3 3-3"/><path d="M12 12v6"/></svg>`
+        };
+        if (node.name.match(/\.(png|jpg|jpeg|gif)$/i)) return { type: 'text', content: '🖼️' };
+        return { type: 'text', content: '📄' };
+    }
 }

--- a/src/utils/diffUtils.ts
+++ b/src/utils/diffUtils.ts
@@ -1,0 +1,238 @@
+import type { ZipNode } from './zipHandler';
+import type { ZipHandler } from './zipHandler';
+import type { MergedZipNode, DiffStatus } from '../types/diff';
+
+/**
+ * Merge two file trees into a single tree with diff status information
+ */
+export function mergeFileTrees(
+    leftTree: ZipNode[],
+    rightTree: ZipNode[]
+): MergedZipNode[] {
+    const nodeMap = new Map<string, MergedZipNode>();
+
+    // Process left tree
+    processTree(leftTree, nodeMap, true, false);
+
+    // Process right tree
+    processTree(rightTree, nodeMap, false, true);
+
+    // Build merged tree structure
+    const merged = buildTreeStructure(nodeMap);
+
+    return merged;
+}
+
+function processTree(
+    nodes: ZipNode[],
+    nodeMap: Map<string, MergedZipNode>,
+    isLeft: boolean,
+    isRight: boolean
+) {
+    for (const node of nodes) {
+        let mergedNode = nodeMap.get(node.path);
+
+        if (!mergedNode) {
+            // Create new merged node
+            mergedNode = {
+                name: node.name,
+                path: node.path,
+                isDir: node.isDir,
+                status: 'both-same', // Will be computed later
+                leftExists: isLeft,
+                rightExists: isRight,
+                children: node.isDir ? [] : undefined
+            };
+            nodeMap.set(node.path, mergedNode);
+        } else {
+            // Update existing node
+            if (isLeft) mergedNode.leftExists = true;
+            if (isRight) mergedNode.rightExists = true;
+        }
+
+        // Process children recursively
+        if (node.children) {
+            processTree(node.children, nodeMap, isLeft, isRight);
+        }
+    }
+}
+
+function buildTreeStructure(nodeMap: Map<string, MergedZipNode>): MergedZipNode[] {
+    const rootNodes: MergedZipNode[] = [];
+    const allNodes = Array.from(nodeMap.values());
+
+    // Build parent-child relationships
+    for (const node of allNodes) {
+        const parentPath = getParentPath(node.path);
+
+        if (!parentPath) {
+            // Root level node
+            rootNodes.push(node);
+        } else {
+            // Child node
+            const parent = nodeMap.get(parentPath);
+            if (parent && parent.children) {
+                parent.children.push(node);
+            } else {
+                // Parent not found, treat as root
+                rootNodes.push(node);
+            }
+        }
+    }
+
+    // Sort children in each node
+    sortTreeNodes(rootNodes);
+
+    return rootNodes;
+}
+
+function getParentPath(path: string): string | null {
+    const lastSlash = path.lastIndexOf('/');
+    if (lastSlash === -1) return null;
+    return path.substring(0, lastSlash);
+}
+
+function sortTreeNodes(nodes: MergedZipNode[]) {
+    nodes.sort((a, b) => {
+        // Directories first
+        if (a.isDir && !b.isDir) return -1;
+        if (!a.isDir && b.isDir) return 1;
+        // Then alphabetically
+        return a.name.localeCompare(b.name);
+    });
+
+    // Sort children recursively
+    for (const node of nodes) {
+        if (node.children && node.children.length > 0) {
+            sortTreeNodes(node.children);
+        }
+    }
+}
+
+/**
+ * Compare file contents from both ZIP handlers
+ */
+export async function compareFileContents(
+    leftZip: ZipHandler,
+    rightZip: ZipHandler,
+    path: string
+): Promise<boolean> {
+    try {
+        const leftContent = await leftZip.getFileContent(path);
+        const rightContent = await rightZip.getFileContent(path);
+
+        // For binary files (Blob), compare size only
+        if (leftContent instanceof Blob && rightContent instanceof Blob) {
+            return leftContent.size === rightContent.size;
+        }
+
+        // For text files, normalize and compare
+        if (typeof leftContent === 'string' && typeof rightContent === 'string') {
+            return normalizeXml(leftContent) === normalizeXml(rightContent);
+        }
+
+        return false;
+    } catch (error) {
+        console.error('Error comparing file contents:', error);
+        return false;
+    }
+}
+
+function normalizeXml(xml: string): string {
+    // Remove all whitespace between tags for comparison
+    return xml.replace(/>\s+</g, '><').trim();
+}
+
+/**
+ * Get SVG icon for diff status
+ */
+export function getDiffStatusIcon(status: DiffStatus): string {
+    switch (status) {
+        case 'both-diff':
+            // Full bidirectional arrows (centered)
+            return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M230.4,384h256c14.14,0,25.6-11.46,25.6-25.6c0-14.14-11.46-25.6-25.6-25.6h-256c-14.14,0-25.6,11.46-25.6,25.6C204.8,372.54,216.26,384,230.4,384"/><path d="M212.3,376.5l102.4,102.4c10,10,26.21,10,36.2,0c10-10,10-26.21,0-36.2L248.5,340.3c-10-10-26.21-10-36.2,0C202.3,350.3,202.3,366.5,212.3,376.5"/><path d="M248.5,376.5l102.4-102.4c10-10,10-26.21,0-36.2c-10-10-26.21-10-36.2,0L212.3,340.3c-10,10-10,26.21,0,36.2C222.3,386.5,238.5,386.5,248.5,376.5"/><path d="M281.6,128h-256C11.46,128,0,139.46,0,153.6c0,14.14,11.46,25.6,25.6,25.6h256c14.14,0,25.6-11.46,25.6-25.6C307.2,139.46,295.74,128,281.6,128"/><path d="M263.5,135.5L161.1,237.9c-10,10-10,26.21,0,36.2c10,10,26.21,10,36.2,0l102.4-102.4c10-10,10-26.21,0-36.2C289.7,125.5,273.5,125.5,263.5,135.5"/><path d="M299.7,135.5L197.3,33.1c-10-10-26.21-10-36.2,0c-10,10-10,26.21,0,36.2l102.4,102.4c10,10,26.21,10,36.2,0C309.7,161.7,309.7,145.5,299.7,135.5"/></svg>`;
+        case 'both-same':
+            // Circle (O) as SVG - thicker stroke
+            return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="none" stroke="currentColor" stroke-width="60"><circle cx="256" cy="256" r="200"/></svg>`;
+        case 'left-only':
+            // Left arrow only - cropped and centered
+            return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="190 220 320 200" fill="currentColor"><path d="M230.4,384h256c14.14,0,25.6-11.46,25.6-25.6c0-14.14-11.46-25.6-25.6-25.6h-256c-14.14,0-25.6,11.46-25.6,25.6C204.8,372.54,216.26,384,230.4,384"/><path d="M212.3,376.5l102.4,102.4c10,10,26.21,10,36.2,0c10-10,10-26.21,0-36.2L248.5,340.3c-10-10-26.21-10-36.2,0C202.3,350.3,202.3,366.5,212.3,376.5"/><path d="M248.5,376.5l102.4-102.4c10-10,10-26.21,0-36.2c-10-10-26.21-10-36.2,0L212.3,340.3c-10,10-10,26.21,0,36.2C222.3,386.5,238.5,386.5,248.5,376.5"/></svg>`;
+        case 'right-only':
+            // Right arrow only - cropped and centered
+            return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 90 320 200" fill="currentColor"><path d="M281.6,128h-256C11.46,128,0,139.46,0,153.6c0,14.14,11.46,25.6,25.6,25.6h256c14.14,0,25.6-11.46,25.6-25.6C307.2,139.46,295.74,128,281.6,128"/><path d="M263.5,135.5L161.1,237.9c-10,10-10,26.21,0,36.2c10,10,26.21,10,36.2,0l102.4-102.4c10-10,10-26.21,0-36.2C289.7,125.5,273.5,125.5,263.5,135.5"/><path d="M299.7,135.5L197.3,33.1c-10-10-26.21-10-36.2,0c-10,10-10,26.21,0,36.2l102.4,102.4c10,10,26.21,10,36.2,0C309.7,161.7,309.7,145.5,299.7,135.5"/></svg>`;
+    }
+}
+
+/**
+ * Recursively compute diff statuses for all nodes
+ */
+export async function computeDiffStatuses(
+    nodes: MergedZipNode[],
+    leftZip: ZipHandler,
+    rightZip: ZipHandler
+): Promise<void> {
+    for (const node of nodes) {
+        await computeNodeStatus(node, leftZip, rightZip);
+
+        // Process children recursively
+        if (node.children && node.children.length > 0) {
+            await computeDiffStatuses(node.children, leftZip, rightZip);
+        }
+    }
+}
+
+async function computeNodeStatus(
+    node: MergedZipNode,
+    leftZip: ZipHandler,
+    rightZip: ZipHandler
+): Promise<void> {
+    // Determine basic status
+    if (node.leftExists && node.rightExists) {
+        // Both exist
+        if (node.isDir) {
+            // For directories, check if any child has diff
+            node.status = await hasChildDiff(node, leftZip, rightZip);
+        } else {
+            // For files, compare contents
+            const match = await compareFileContents(leftZip, rightZip, node.path);
+            node.contentsMatch = match;
+            node.status = match ? 'both-same' : 'both-diff';
+        }
+    } else if (node.leftExists && !node.rightExists) {
+        node.status = 'left-only';
+    } else if (!node.leftExists && node.rightExists) {
+        node.status = 'right-only';
+    } else {
+        // Shouldn't happen
+        node.status = 'both-same';
+    }
+}
+
+async function hasChildDiff(
+    node: MergedZipNode,
+    leftZip: ZipHandler,
+    rightZip: ZipHandler
+): Promise<DiffStatus> {
+    if (!node.children || node.children.length === 0) {
+        return 'both-same';
+    }
+
+    // Check if any child has a diff
+    for (const child of node.children) {
+        await computeNodeStatus(child, leftZip, rightZip);
+
+        if (child.status !== 'both-same') {
+            return 'both-diff';
+        }
+
+        // Check grandchildren recursively
+        if (child.isDir && child.children) {
+            const childStatus = await hasChildDiff(child, leftZip, rightZip);
+            if (childStatus === 'both-diff') {
+                return 'both-diff';
+            }
+        }
+    }
+
+    return 'both-same';
+}

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,0 +1,40 @@
+/**
+ * DOM utility functions for creating styled elements
+ */
+
+export function createElement<K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    options?: {
+        className?: string;
+        textContent?: string;
+        innerHTML?: string;
+        style?: Partial<CSSStyleDeclaration>;
+        attributes?: Record<string, string>;
+    }
+): HTMLElementTagNameMap[K] {
+    const element = document.createElement(tag);
+
+    if (options?.className) {
+        element.className = options.className;
+    }
+
+    if (options?.textContent) {
+        element.textContent = options.textContent;
+    }
+
+    if (options?.innerHTML) {
+        element.innerHTML = options.innerHTML;
+    }
+
+    if (options?.style) {
+        Object.assign(element.style, options.style);
+    }
+
+    if (options?.attributes) {
+        Object.entries(options.attributes).forEach(([key, value]) => {
+            element.setAttribute(key, value);
+        });
+    }
+
+    return element;
+}


### PR DESCRIPTION
## Diff 모드 구현
- DiffMode 클래스 추가: 두 파일 동시 로드 및 비교 모드 관리
- DiffEditor 클래스 추가: @codemirror/merge의 MergeView 사용하여 양쪽 파일 비교
  - 양쪽 편집기 동기화된 검색 패널
  - 각 파일 개별 저장 및 다운로드 기능
  - 이미지 파일 양쪽 비교 뷰
- diffUtils 추가: 파일 트리 병합 및 diff 상태 계산 (added/modified/deleted/unchanged)
- MergedZipNode 타입 추가: 양쪽 파일 존재 여부 및 diff 상태 관리
- Diff 모드 UI: 양쪽 파일명 표시, 개별 다운로드 버튼

## 클래스 상속 구조 리팩토링
- BaseMode 추가: 트리 관리, 애니메이션, 삭제 경고 공통 로직 추상화
- BaseEditor 추가: relationship 파일 처리, XML 포매팅 공통 로직 추상화
- SingleMode → Mode로 이름 변경
- TreeView/DiffTreeView → 단일 TreeView 클래스로 통합 (isDiffMode 플래그 사용)
- 중복 코드 약 470줄 제거

## 기타 개선
- README.md에 아키텍처 문서화
- constants.ts로 상수 분리
- domUtils, editorUtils 유틸리티 추가