### PR TITLE
fix: add .vml file support for XML viewing

### DIFF
--- a/src/const/constants.ts
+++ b/src/const/constants.ts
@@ -35,6 +35,6 @@ export const DELETE_ANIMATION_DURATION = 300; // ms
  * File extensions
  */
 export const FILE_EXTENSIONS = {
-    XML: ['.xml', '.rels'],
+    XML: ['.xml', '.rels', '.vml'],
     IMAGE: ['.png', '.jpg', '.jpeg', '.gif']
 } as const;

--- a/src/utils/zipHandler.ts
+++ b/src/utils/zipHandler.ts
@@ -68,7 +68,7 @@ export class ZipHandler {
 
         // Check extension to decide return type
         const lowerPath = path.toLowerCase();
-        if (lowerPath.endsWith('.xml') || lowerPath.endsWith('.rels') || lowerPath.endsWith('.txt')) {
+        if (lowerPath.endsWith('.xml') || lowerPath.endsWith('.rels') || lowerPath.endsWith('.txt') || lowerPath.endsWith('.vml')) {
             return await file.async('string');
         } else {
             return await file.async('blob');


### PR DESCRIPTION
closes #7 

VML (Vector Markup Language) files are XML-based but were not recognized as text files, causing them to be treated as binary and fail to open.